### PR TITLE
Make requirement of puppetlabs-postgresql repo management optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,7 @@ class pgbouncer (
   $userlist_file              = $pgbouncer::params::userlist_file,
   $deb_default_file           = $pgbouncer::params::deb_default_file,
   $service_start_with_system  = $pgbouncer::params::service_start_with_system,
+  $require_repo               = $pgbouncer::params::require_repo,
 ) inherits pgbouncer::params {
 
   # merge the defaults and custom params
@@ -101,13 +102,13 @@ class pgbouncer (
   # Same package name for both redhat based and debian based
   case $::osfamily {
     'RedHat', 'Linux': {
+      $package_require = $require_repo ? {
+        true  => [ Class['postgresql::repo::yum_postgresql_org'], Anchor['pgbouncer::begin'] ],
+        false => Anchor['pgbouncer::begin'],
+      }
       package{ $pgbouncer_package_name:
         ensure  => installed,
-        require => [
-          Class[
-            'postgresql::repo::yum_postgresql_org'],
-            Anchor['pgbouncer::begin']
-          ],
+        require => $package_require,
       }
     }
     'FreeBSD', 'Debian': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class pgbouncer::params {
   $config_params              = undef
   $pgbouncer_package_name     = 'pgbouncer'
   $service_start_with_system  = true
+  $require_repo               = true
 
   # === Set OS specific variables === #
   case $::osfamily {


### PR DESCRIPTION
We have our own internal repositories as not all systems are able to reach the Internet. This simply removes the hard dependency on the PGDG repository by providing an option to not require the repository.
