### PR TITLE
Ensure userlist is owned by the pgbouncer user and not world readable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,8 @@ class pgbouncer (
   $userlist_file              = $pgbouncer::params::userlist_file,
   $deb_default_file           = $pgbouncer::params::deb_default_file,
   $service_start_with_system  = $pgbouncer::params::service_start_with_system,
+  $user                       = $pgbouncer::params::user,
+  $group                      = $pgbouncer::params::group,
 ) inherits pgbouncer::params {
 
   # merge the defaults and custom params
@@ -122,11 +124,17 @@ class pgbouncer (
   # verify we have config file managed by concat
   concat { $conffile:
     ensure => present,
+    owner  => $user,
+    group  => $group,
+    mode   => '0640',
   }
 
   # verify we have auth_file managed by concat
   concat { $userlist_file:
     ensure => present,
+    owner  => $user,
+    group  => $group,
+    mode   => '0640',
   }
   
   # build the pgbouncer parameter piece of the config file

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,8 @@ class pgbouncer::params {
   $config_params              = undef
   $pgbouncer_package_name     = 'pgbouncer'
   $service_start_with_system  = true
+  $user                       = 'pgbouncer'
+  $group                      = 'pgbouncer'
 
   # === Set OS specific variables === #
   case $::osfamily {
@@ -20,8 +22,6 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/userlist.txt"
       $unix_socket_dir         = '/tmp'
-      $user                    = 'pgbouncer'
-      $group                   = 'pgbouncer'
     }
     'Debian': {
       $logfile                 = '/var/log/postgresql/pgbouncer.log'
@@ -31,8 +31,6 @@ class pgbouncer::params {
       $userlist_file           = "${confdir}/userlist.txt"
       $unix_socket_dir         = '/var/run/postgresql'
       $deb_default_file        = '/etc/default/pgbouncer'
-      $user                    = 'pgbouncer'
-      $group                   = 'pgbouncer'
     }
     'FreeBSD': {
       $logfile                 = '/var/log/pgbouncer/pgbouncer.log'
@@ -41,8 +39,6 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/pgbouncer.users"
       $unix_socket_dir         = '/tmp'
-      $user                    = 'pgbouncer'
-      $group                   = 'pgbouncer'
     }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,8 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/userlist.txt"
       $unix_socket_dir         = '/tmp'
+      $user                    = 'pgbouncer'
+      $group                   = 'pgbouncer'
     }
     'Debian': {
       $logfile                 = '/var/log/postgresql/pgbouncer.log'
@@ -29,6 +31,8 @@ class pgbouncer::params {
       $userlist_file           = "${confdir}/userlist.txt"
       $unix_socket_dir         = '/var/run/postgresql'
       $deb_default_file        = '/etc/default/pgbouncer'
+      $user                    = 'pgbouncer'
+      $group                   = 'pgbouncer'
     }
     'FreeBSD': {
       $logfile                 = '/var/log/pgbouncer/pgbouncer.log'
@@ -37,6 +41,8 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/pgbouncer.users"
       $unix_socket_dir         = '/tmp'
+      $user                    = 'pgbouncer'
+      $group                   = 'pgbouncer'
     }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")


### PR DESCRIPTION
This changes the ownership of the pgbouncer configuration and userlist file to the pgbouncer user and prevents world read access to these potentially sensitive files. I have only tested this on CentOS, but it seems to work.
