### PR TITLE
updated to be compatible with puppet 4.x strict variables

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,7 +147,7 @@ class pgbouncer (
   }
 
   # check if debian
-  if $::osfamily == 'Debian' {
+  if $::osfamily == 'Debian' and $deb_default_file {
     file{ $deb_default_file:
       ensure  => file,
       source  => 'puppet:///modules/pgbouncer/pgbouncer',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/userlist.txt"
       $unix_socket_dir         = '/tmp'
+      $deb_default_file        = undef
     }
     'Debian': {
       $logfile                 = '/var/log/postgresql/pgbouncer.log'
@@ -40,6 +41,7 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/pgbouncer.users"
       $unix_socket_dir         = '/tmp'
+      $deb_default_file        = undef
     }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")


### PR DESCRIPTION
Using puppet 4 with strict_variables = true, found an uniniitialised variable. Have set a default to undef for all non-Debian environments, and an additional check to ensure the variable is set when in use.
