### PR TITLE
Make database host optional to allow for the use of a unix socket

### DIFF
--- a/templates/pgbouncer.ini.databases.part2.erb
+++ b/templates/pgbouncer.ini.databases.part2.erb
@@ -1,6 +1,6 @@
 ; Created from: <%= @name %>
 <% if @databases -%>
 <%  @databases.each do |entry| -%>
-<%=   %Q|#{entry['source_db']} = host=#{entry['host']}| %><% if entry['port'] %><%= %Q| port=#{entry['port']}| %><% end %><% if entry['dest_db'] %><%= %Q| dbname=#{entry['dest_db']}| %><% end %><% if entry['auth_user'] %><%= %Q| user=#{entry['auth_user']}| %><% end %><% if entry['auth_pass'] %><%= %Q| password=#{entry['auth_pass']}| %><% end %><% if entry['pool_size'] %><%= %Q| pool_size=#{entry['pool_size']}| %><% end %>
+<%= %Q|#{entry['source_db']} | %>=<% if entry['host'] %><%= %Q| host=#{entry['host']}| %><% end %><% if entry['port'] %><%= %Q| port=#{entry['port']}| %><% end %><% if entry['dest_db'] %><%= %Q| dbname=#{entry['dest_db']}| %><% end %><% if entry['auth_user'] %><%= %Q| user=#{entry['auth_user']}| %><% end %><% if entry['auth_pass'] %><%= %Q| password=#{entry['auth_pass']}| %><% end %><% if entry['pool_size'] %><%= %Q| pool_size=#{entry['pool_size']}| %><% end %>
 <%  end -%>
 <% end %>


### PR DESCRIPTION
This commit allows for the use of a socket by making the host parameter optional. See the 'host' section of https://pgbouncer.github.io/config.html#section-databases for details.
