### PR TITLE
Allow for pgbouncer online restarts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,7 @@ class pgbouncer (
   $userlist_file              = $pgbouncer::params::userlist_file,
   $deb_default_file           = $pgbouncer::params::deb_default_file,
   $service_start_with_system  = $pgbouncer::params::service_start_with_system,
+  $service_hasrestart         = $pgbouncer::params::service_hasrestart,
   $user                       = $pgbouncer::params::user,
   $group                      = $pgbouncer::params::group,
   $require_repo               = $pgbouncer::params::require_repo,
@@ -187,9 +188,10 @@ class pgbouncer (
   validate_bool($service_start_with_system)
 
   service {'pgbouncer':
-    ensure    => running,
-    enable    => $service_start_with_system,
-    subscribe => Concat[$userlist_file, $conffile],
+    ensure     => running,
+    enable     => $service_start_with_system,
+    hasrestart => $service_hasrestart,
+    subscribe  => Concat[$userlist_file, $conffile],
   }
 
   anchor{'pgbouncer::end':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/userlist.txt"
       $unix_socket_dir         = '/tmp'
+      $service_hasrestart      = true
     }
     'Debian': {
       $logfile                 = '/var/log/postgresql/pgbouncer.log'
@@ -32,6 +33,7 @@ class pgbouncer::params {
       $userlist_file           = "${confdir}/userlist.txt"
       $unix_socket_dir         = '/var/run/postgresql'
       $deb_default_file        = '/etc/default/pgbouncer'
+      $service_hasrestart      = true
     }
     'FreeBSD': {
       $logfile                 = '/var/log/pgbouncer/pgbouncer.log'
@@ -40,6 +42,7 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/pgbouncer.users"
       $unix_socket_dir         = '/tmp'
+      $service_hasrestart      = undef
     }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")


### PR DESCRIPTION
Currently, when the pgbouncer config changes in a way that requires a refresh, Puppet issues a stop/start causing a brief interruption of service. The pgbouncer package's init script (on RHEL/CentOS) specifies the -R flag for restart, which tells pgbouncer to do an online restart. I can't speak for every platform, but it seems better to use the restart function where possible.
