### PR TITLE
Ensure resource ordering & Debian fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,13 +109,14 @@ class pgbouncer (
         false => Anchor['pgbouncer::begin'],
       }
       package{ $pgbouncer_package_name:
-        ensure  => installed,
-        require => $package_require,
+        ensure => installed,
+        before => $package_require,
       }
     }
     'FreeBSD', 'Debian': {
       package{ $pgbouncer_package_name:
-        ensure  => installed,
+        ensure => installed,
+        before => Anchor['pgbouncer::begin'],
       }
     }
     default: {
@@ -124,18 +125,20 @@ class pgbouncer (
   }
   # verify we have config file managed by concat
   concat { $conffile:
-    ensure => present,
-    owner  => $user,
-    group  => $group,
-    mode   => '0640',
+    ensure  => present,
+    owner   => $user,
+    group   => $group,
+    mode    => '0640',
+    require => Anchor['pgbouncer::begin'],
   }
 
   # verify we have auth_file managed by concat
   concat { $userlist_file:
-    ensure => present,
-    owner  => $user,
-    group  => $group,
-    mode   => '0640',
+    ensure  => present,
+    owner   => $user,
+    group   => $group,
+    mode    => '0640',
+    require => Anchor['pgbouncer::begin'],
   }
 
   # build the pgbouncer parameter piece of the config file

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,14 +109,13 @@ class pgbouncer (
         false => Anchor['pgbouncer::begin'],
       }
       package{ $pgbouncer_package_name:
-        ensure => installed,
-        before => $package_require,
+        ensure  => installed,
+        require => $package_require,
       }
     }
     'FreeBSD', 'Debian': {
       package{ $pgbouncer_package_name:
         ensure => installed,
-        before => Anchor['pgbouncer::begin'],
       }
     }
     default: {
@@ -129,7 +128,7 @@ class pgbouncer (
     owner   => $user,
     group   => $group,
     mode    => '0640',
-    require => Anchor['pgbouncer::begin'],
+    require => Package[$pgbouncer_package_name],
   }
 
   # verify we have auth_file managed by concat
@@ -138,7 +137,7 @@ class pgbouncer (
     owner   => $user,
     group   => $group,
     mode    => '0640',
-    require => Anchor['pgbouncer::begin'],
+    require => Package[$pgbouncer_package_name],
   }
 
   # build the pgbouncer parameter piece of the config file

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -161,7 +161,7 @@ class pgbouncer (
   # check if we have an authlist
   if $userlist {
     pgbouncer::userlist{ 'pgbouncer_module_userlist':
-      auth_list => $userlist,
+      auth_list    => $userlist,
       paramtmpfile => $paramtmpfile,
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,8 +10,6 @@ class pgbouncer::params {
   $config_params              = undef
   $pgbouncer_package_name     = 'pgbouncer'
   $service_start_with_system  = true
-  $user                       = 'pgbouncer'
-  $group                      = 'pgbouncer'
   $require_repo               = true
 
   # === Set OS specific variables === #
@@ -23,6 +21,8 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/userlist.txt"
       $unix_socket_dir         = '/tmp'
+      $user                    = 'pgbouncer'
+      $group                   = 'pgbouncer'
     }
     'Debian': {
       $logfile                 = '/var/log/postgresql/pgbouncer.log'
@@ -32,6 +32,8 @@ class pgbouncer::params {
       $userlist_file           = "${confdir}/userlist.txt"
       $unix_socket_dir         = '/var/run/postgresql'
       $deb_default_file        = '/etc/default/pgbouncer'
+      $user                    = 'postgres'
+      $group                   = 'postgres'
     }
     'FreeBSD': {
       $logfile                 = '/var/log/pgbouncer/pgbouncer.log'
@@ -40,6 +42,8 @@ class pgbouncer::params {
       $conffile                = "${confdir}/pgbouncer.ini"
       $userlist_file           = "${confdir}/pgbouncer.users"
       $unix_socket_dir         = '/tmp'
+      $user                    = 'pgbouncer'
+      $group                   = 'pgbouncer'
     }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")


### PR DESCRIPTION
This PR fixes resource ordering during first installation. First we need to install `pgbouncer` package, then we can ensure file ownership (user account might not exist before).

Second commit changes defaults for Debian, where pgbouncer files are owned by `postgres` user.
