### PR TITLE
database: Use `auth_user` directive as intended

### DIFF
--- a/templates/pgbouncer.ini.databases.part2.erb
+++ b/templates/pgbouncer.ini.databases.part2.erb
@@ -1,6 +1,6 @@
 ; Created from: <%= @name %>
 <% if @databases -%>
 <%  @databases.each do |entry| -%>
-<%=   %Q|#{entry['source_db']} = host=#{entry['host']}| %><% if entry['port'] %><%= %Q| port=#{entry['port']}| %><% end %><% if entry['dest_db'] %><%= %Q| dbname=#{entry['dest_db']}| %><% end %><% if entry['auth_user'] %><%= %Q| user=#{entry['auth_user']}| %><% end %><% if entry['auth_pass'] %><%= %Q| password=#{entry['auth_pass']}| %><% end %><% if entry['pool_size'] %><%= %Q| pool_size=#{entry['pool_size']}| %><% end %>
+<%=   %Q|#{entry['source_db']} = host=#{entry['host']}| %><% if entry['port'] %><%= %Q| port=#{entry['port']}| %><% end %><% if entry['dest_db'] %><%= %Q| dbname=#{entry['dest_db']}| %><% end %><% if entry['auth_user'] %><%= %Q| auth_user=#{entry['auth_user']}| %><% end %><% if entry['user'] %><%= %Q| user=#{entry['user']}| %><% end %><% if entry['auth_pass'] %><%= %Q| password=#{entry['auth_pass']}| %><% end %><% if entry['pool_size'] %><%= %Q| pool_size=#{entry['pool_size']}| %><% end %>
 <%  end -%>
 <% end %>


### PR DESCRIPTION
Prior to this commit, the `auth_user` directive was translated as `user`
directive. Those directives are not the same.

The `user` directive expects credentials to be solved either by the userlist.txt
mechanism or by a password provided in the database entry.

The `auth_user` directive allows the credentials to be solved through querying.

Ultimately, it must be the module's user to decide which to use.

Related #31